### PR TITLE
Fix 1.0 react-router dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/svenanders/react-breadcrumbs",
   "peerDependencies": {
     "react": "^0.13.x",
-    "react-router": "^0.13.x"
+    "react-router": "^1.0.0-alpha1"
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Addresses bug:
```
npm ERR! peerinvalid The package react-router@1.0.0-rc1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-breadcrumbs@1.0.1 wants react-router@^0.13.x
```
when trying to `npm install react-breadcrumbs@1.0.1` with react-router 1.0.0+.