### PR TITLE
Update react-router dependency to allow for stable 1.0 releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/svenanders/react-breadcrumbs",
   "peerDependencies": {
     "react": ">=0.12.2 <0.15.0",
-    "react-router": ">=1.0.0-alpha1 <=1.0.0-rc4"
+    "react-router": "^1.0.0-alpha1"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
This leaves open option to use with all pre-release 1.0 react-router versions; it's likely you'll want to eventually close them off (via `^1.0.0`). You could also decide to do this now, if so, please ignore PR.

Also used `^` instead of `~` because I trust the react-router folks will correctly use semver.

Thanks much!