### PR TITLE
Now appending inherited path for nested routes - fixes #22

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -94,7 +94,19 @@ class Breadcrumbs extends React.Component {
   _buildRoutes(routes) {
     let crumbs = [];
     let isRoot = routes[1].hasOwnProperty("path");
-    routes.map(route => {
+    routes.map(route, index => {
+      if (0 < index && 'path' in route && '/' !== route.path.substr(0, 1)) {
+        let parentPath = '';
+
+        for (let i = 0; i < index; i++) {
+            if ('path' in routes[i]) {
+              parentPath += routes[i].path;
+            }
+        }
+
+        route.path = parentPath + route.path;
+      }
+
       let result = this._processRoute(route,routes.length,crumbs.length,isRoot);
       if (result) {
         crumbs.push(result);


### PR DESCRIPTION
This fixes [this issue](https://github.com/svenanders/react-breadcrumbs/issues/22), that I thought had disappeared with v1.1.4 but apparently hasn't.

When iterating over routes before processing, if the route isn't the first one in the array (base route) and doesn't have an absolute path (which starts with `/`), I prepend it with each previous route's path in order to build an absolute one, which is used instead for processing.

Not sure this meets all of your requirements, but it works on my side and I have covered as much cases as I could think of.