### PR TITLE
use es6 module syntax

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -260,4 +260,4 @@ Breadcrumbs.contextTypes = {
   params: React.PropTypes.array
 };
 
-module.exports = Breadcrumbs;
+export default Breadcrumbs;


### PR DESCRIPTION
ES6 modules should use ES6 module syntax unless there is a good reason not to.  Format inference doesn't work properly when there is a mixture of es6 and commonjs elements.