### PR TITLE
check staticName prop on Route to prevent using params for breadcrumb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ The demo is using this route setup:
 </Router>
 ```
 
+Routes with parameterized paths default to using the parameter value as the breadcrumb name. However, there may be a case where you want to override this behavior.  
+If you want to force the route to use the name value provided you can add the `staticName` prop to the `Route`:
+
+```jsx
+<Route name="UserLocator" staticName={true} path=":userId" component={User}>
+```
+
 ## Usage
 
 ```jsx

--- a/index.jsx
+++ b/index.jsx
@@ -104,7 +104,7 @@ class Breadcrumbs extends React.Component {
             }
           })
           route.path=pathWithParam.reduce((start,link)=>{return start+"/"+link;})
-          if(currentKey.substring(0,1)==":") 
+          if(!route.staticName && currentKey.substring(0,1)==":")
             name=pathWithParam.reduce((start,link)=>{return link;});
         }
       }


### PR DESCRIPTION
… and use the name provided