### PR TITLE
dynamic route name

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -22,10 +22,14 @@ class Breadcrumbs extends React.Component {
   _getDisplayName(route) {
     let name = null;
 
+    if (typeof route.getDisplayName === 'function') {
+      name = route.getDisplayName();
+    }
+
     if(route.indexRoute) {
-      name = route.indexRoute.displayName || null;
+      name = name || route.indexRoute.displayName || null;
     } else {
-      name = route.displayName || null;
+      name = name || route.displayName || null;
     }
 
     //check to see if a custom name has been applied to the route
@@ -148,7 +152,7 @@ class Breadcrumbs extends React.Component {
 
     let routesWithExclude = [];
     routes.forEach((_route, index) => {
-      let route = JSON.parse(JSON.stringify(_route));
+      let route = Object.assign({}, _route);
       if (typeof _route.prettifyParam === 'function'){
         route.prettifyParam = _route.prettifyParam;
       }
@@ -240,7 +244,7 @@ Breadcrumbs.propTypes = {
   wrapperClass: React.PropTypes.string,
   itemElement: React.PropTypes.string,
   itemClass: React.PropTypes.string,
-  customClass: React.PropTypes.string,  
+  customClass: React.PropTypes.string,
   activeItemClass: React.PropTypes.string,
   excludes: React.PropTypes.arrayOf(React.PropTypes.string),
   hideNoPath: React.PropTypes.bool,


### PR DESCRIPTION
This PR is related to the Issue #27

I need to localize the route names displayed in breadcrumbs. I have a language switcher on the page which changes site locale without page reloading and breadcrumbs should dynamically change together with the rest of the page. The idea is to generate a name by a custom function when required.

I changed usage of `JSON.parse(JSON.stringify(_route))` to `Object.assign` because JSON serialization/deserialization removes all the functions from an object making it impossible to pass a name generation function in route props.

Now a route definition may look as follows:
```
<Router history={browserHistory}>
        <Route
          name="Home"
          getDisplayName={() => l20nMessage('homeTitle', 'Home')}
          id="APP"
          path={routes.APP.path}
          component={Layout}
        >
          <Route
            id="PORTAL"
            name="Portal"
            getDisplayName={() => l20nMessage('portalTitle', 'Portal')}
            path={routes.PORTAL.path}
            component={PortalPage}
          />
...
```