### PR TITLE
Remove `customClass` from `defaultProps`.

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -266,7 +266,6 @@ Breadcrumbs.defaultProps = {
   itemElement: "span",
   itemClass: "",
   activeItemClass: "",
-  customClass: "breadcrumbs",
   excludes: [''],
   prettify: false,
   hideNoPath: true,


### PR DESCRIPTION
`customClass` is deprecated, having it in `defaultProps` means it will overwrite `wrapperClass`. (line 219)