### PR TITLE
Fix for issue where under some routes links and seperators are not di…

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -66,7 +66,7 @@ class Breadcrumbs extends React.Component {
         'excludes' in this.props &&
         this.props.excludes.some(item => item === name)) return null;
 
-    let makeLink=isRoot;
+    let makeLink=true;
 
     // don't make link if route doesn't have a child route
     if(makeLink){


### PR DESCRIPTION
Tests appear to pass (no output from npm test).  

This fix is related to this discussion

https://github.com/svenanders/react-breadcrumbs/issues/50

I am not sure of what other side effects of overriding the isRoot flag may occur, but this works perfectly for my routes.
