### PR TITLE
Add createElement property

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ This will print all breadcrumbs, except for the one where the route name is `App
 Starting with v1.3.4, this will set the document title to your last item in the breadcrumbs.
 
 ```jsx
+<Breadcrumbs createElement={false} />
+```
+
+This property allows you to choose whether a wrapper element is created around the breadcrumb. When false,
+no wrapper element is created, allowing you to create your own wrapper with custom props.
+
+```jsx
 <Breadcrumbs displayMissing="true|false" displayMissingText="This title is missing" />
 ```
 
@@ -136,7 +143,7 @@ hide or show these in the breadcrumbs.
 
 ## Styling
 
-The breadcrumbs are set up with a div with the class name "breadcrumbs".
+The breadcrumbs are set up in a div with the class name "breadcrumbs".
 
 [1]: https://facebook.github.io/react
 [2]: http://breadcrumbs.surge.sh/index.html

--- a/index.jsx
+++ b/index.jsx
@@ -219,21 +219,22 @@ class Breadcrumbs extends React.Component {
 
   }
 
-  render(createElement=true) {
-    return this._buildRoutes(this.props.routes, createElement);
+  render() {
+    return this._buildRoutes(this.props.routes, this.props.createElement);
   }
 }
 
 /**
  * @property PropTypes
  * @description Property types supported by this component
- * @type {{separator: *, displayMissing: *, displayName: *, breadcrumbName: *, wrapperElement: *, wrapperClass: *, itemElement: *, itemClass: *, activeItemClass: *,  customClass: *,excludes: *}}
+ * @type {{separator: *, createElement: *, displayMissing: *, displayName: *, breadcrumbName: *, wrapperElement: *, wrapperClass: *, itemElement: *, itemClass: *, activeItemClass: *,  customClass: *,excludes: *}}
  */
 Breadcrumbs.propTypes = {
   separator: React.PropTypes.oneOfType([
     React.PropTypes.element,
     React.PropTypes.string
   ]),
+  createElement: React.PropTypes.bool,
   displayMissing: React.PropTypes.bool,
   prettify: React.PropTypes.bool,
   displayMissingText: React.PropTypes.string,
@@ -258,6 +259,7 @@ Breadcrumbs.propTypes = {
  */
 Breadcrumbs.defaultProps = {
   separator: " > ",
+  createElement: true,
   displayMissing: true,
   displayMissingText: "Missing name prop from Route",
   wrapperElement: "div",


### PR DESCRIPTION
This property allows you to choose whether a wrapper element is created around the breadcrumb. When false, no wrapper element is created, allowing you to create your own wrapper with custom props.