### PR TITLE
Breadcrumbs incorrectly render when displayMissing is false.

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -175,7 +175,7 @@ class Breadcrumbs extends React.Component {
         route.path = parentPath;
       }
       let name = this._resolveRouteName(route);
-      if(route.path && !('excludes' in this.props && this.props.excludes.some(item => item === name)))
+      if ((this.props.displayMissing || name) && route.path && !('excludes' in this.props && this.props.excludes.some(item => item === name)))
         routesWithExclude.push(route);
     });
     routes=routesWithExclude;


### PR DESCRIPTION
Here is an example of a route, where the final two items are  named, but the first ones are not:
![image](https://cloud.githubusercontent.com/assets/8441810/18796013/42f972b4-81bf-11e6-96fd-c31195815f4f.png)

Here it is when displayMissing is false:
![image](https://cloud.githubusercontent.com/assets/8441810/18796053/6b011258-81bf-11e6-843c-73d15fc1c39a.png)


This PR fixes the issue by removing routes with no name before they are added to the list of routes to render. (ignore the seperator change)

![image](https://cloud.githubusercontent.com/assets/8441810/18796131/c39e72de-81bf-11e6-8126-10a3729a9521.png)
