### PR TITLE
Add support for custom Link components

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Erik Anderson <erikbpanderson@gmail.com>
 FoxxMD <matt.duncan13@gmail.com>
 Guilherme Caminha <gpkc@cin.ufpe.br>
 Jack Coulter <jscinoz@jscinoz.so>
+Jack Allan <jackgeek@gmail.com>
 Jonas Matser <jonas@jonasmatser.nl>
 Lance Batson <lancebatsondev@gmail.com>
 Lee Siong Chan <leesiongchan@users.noreply.github.com>

--- a/index.jsx
+++ b/index.jsx
@@ -129,7 +129,7 @@ class Breadcrumbs extends React.Component {
       var itemClass = this.props.itemClass;
       if(makeLink){
         var link = !createElement ? name:
-          React.createElement(Link, {
+          React.createElement(this.props.Link || Link, {
           to: route.path,
         }, name);
       } else {


### PR DESCRIPTION
I have a need to execute code before the user navigates to the Links in the breadcrumbs component.  The nicest way would be to be able to specify my own Link component to be used instead instead of the react-router Link component.  This gives me full control over how the links get rendered.