### PR TITLE
Fix "Uncaught TypeError: Cannot read property 'props' of undefined" w…

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -208,7 +208,7 @@ class Breadcrumbs extends React.Component {
     });
     if (ExecutionEnvironment.canUseDOM){
       if(window && window.document){
-        if('setDocumentTitle' in this.props && this.props.setDocumentTitle) {
+        if('setDocumentTitle' in this.props && this.props.setDocumentTitle && crumbs.length > 0) {
         window.document.title = crumbs[crumbs.length-1].props.children[0];
         }
       }


### PR DESCRIPTION
…hen setDocumentTitle={true} and excludes={["App"]}

There is a bug which appears on the root route, when breadcrumb is configured with `setDocumentTitle={true}` and `excludes={["App"]}`. The bug is due to a missing check for array length in `crumbs[crumbs.length-1].props`, so when `crumbs = []` it tries to access `crumbs[-1].props` which obviously fails.

Please merge and publish update.