### PR TITLE
Fix propTypes

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -240,9 +240,15 @@ Breadcrumbs.propTypes = {
   displayMissingText: React.PropTypes.string,
   displayName: React.PropTypes.string,
   breadcrumbName: React.PropTypes.string,
-  wrapperElement: React.PropTypes.string,
+  wrapperElement: React.PropTypes.oneOfType([
+    React.PropTypes.element,
+    React.PropTypes.string
+  ]),
   wrapperClass: React.PropTypes.string,
-  itemElement: React.PropTypes.string,
+  itemElement: React.PropTypes.oneOfType([
+    React.PropTypes.element,
+    React.PropTypes.string
+  ]),
   itemClass: React.PropTypes.string,
   customClass: React.PropTypes.string,
   activeItemClass: React.PropTypes.string,


### PR DESCRIPTION
Allow elements for wrapper/item elements. Works perfectly now, but raises warnings because of wrong type.