### PR TITLE
linkProps

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -300,19 +300,19 @@ Breadcrumbs.propTypes = {
   ]),
   'createElement': PropTypes.bool,
   'Link': PropTypes.oneOfType([
-    PropTypes.element,
+    PropTypes.func,
     PropTypes.string
   ]),
   'displayMissing': PropTypes.bool,
   'prettify': PropTypes.bool,
   'displayMissingText': PropTypes.string,
   'wrapperElement': PropTypes.oneOfType([
-    PropTypes.element,
+    PropTypes.func,
     PropTypes.string
   ]),
   'wrapperClass': PropTypes.string,
   'itemElement': PropTypes.oneOfType([
-    PropTypes.element,
+    PropTypes.func,
     PropTypes.string
   ]),
   'itemClass': PropTypes.string,

--- a/index.jsx
+++ b/index.jsx
@@ -179,13 +179,19 @@ class Breadcrumbs extends React.Component {
       })
     }
 
+    let linkProps = {};
+
+    if (Object.prototype.hasOwnProperty.call(route, 'linkProps')) {
+      linkProps = route.linkProps
+    }
+
     var link = name
     var itemClass = this.props.itemClass
     if (makeLink) {
       if (createElement) {
         link = React.createElement(
           this.props.Link || Link,
-          { 'to': route.path },
+          Object.assign({ 'to': route.path }, linkProps),
           name
         )
       }


### PR DESCRIPTION
Allow to pass props to Link component from a Route - usefull when we have a custom Link component and want to specify some props for specific link.

I also change propTypes for 'Link', 'wrapperElement', 'itemElement' from PropTypes.element to PropTypes.func to avoid warning when we pass custom Element type.