### PR TITLE
Fix demo CrumbRoute component

### DIFF
--- a/demo/src/crumb-route.jsx
+++ b/demo/src/crumb-route.jsx
@@ -15,7 +15,7 @@ export default ({
   <Route { ...props } render={ routeProps => (
     <Breadcrumb data={{
     	title: props.title,
-    	pathname: routeProps.match.path,
+    	pathname: routeProps.match.url,
     	search: includeSearch ? routeProps.location.search : null
     }}>
     	{ Component ? <Component { ...routeProps } /> : render(routeProps) }


### PR DESCRIPTION
Use match.url otherwise the link will contain something like that `/path/to/:id/`
From react-router docs:

```
path - (string) The path pattern used to match. Useful for building nested <Route>s
url - (string) The matched portion of the URL. Useful for building nested <Link>s
```

  