### PR TITLE
chore(dev-dependency): Add needed babel preset dependency

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/svenanders/react-breadcrumbs#readme",
   "devDependencies": {
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "css-loader": "^0.28.7",
     "style-loader": "^0.18.2",


### PR DESCRIPTION
This PR aims to solve a problem when running demo.

Before adding the dependency the following error message is raised when running `npm start`

![screen shot 2018-06-11 at 12 03 19](https://user-images.githubusercontent.com/1799845/41225875-289d1c24-6d70-11e8-9611-cbe1db61d8df.png)

After the fix everything is working fine.

