### PR TITLE
fix: allow usage with latest react-router version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-router-dom": "^4.0.0",
+    "react-router-dom": "^4.0.0 || ^5.0.0",
     "prop-types": "^15.5.7"
   },
   "devDependencies": {


### PR DESCRIPTION
`react-router-dom@5` is supposed to be totally backwards compatible. The only breaking
change I've noticed is if you access its context directly and I don't think that's done
anywhere in this repo. I think that was kind of a hidden feature we weren't "supposed" to be
using anyway.